### PR TITLE
Remove ar.conf mount from chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wazuh Helm Chart
 
-![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square)
+![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square)
 ![AppVersion: 4.12.0](https://img.shields.io/badge/AppVersion-4.12.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/wazuh-helm)](https://artifacthub.io/packages/helm/wazuh-helm/wazuh)
 

--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -3,7 +3,7 @@ name: wazuh
 description: Wazuh is a free and open source security platform that unifies XDR and SIEM protection for endpoints and cloud workloads.
 type: application
 appVersion: 4.12.0
-version: 0.0.10
+version: 0.0.11
 home: https://wazuh.com/
 sources:
   - https://github.com/promptlylabs/wazuh-helm-chart
@@ -29,7 +29,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/changes: |
     - kind: changed
-      description: Require Wazuh >= 4.12.0 and remove legacy configuration
+      description: Remove ar.conf active response configuration and volume mounts
   # artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: application source

--- a/charts/wazuh/README.md
+++ b/charts/wazuh/README.md
@@ -1,6 +1,6 @@
 # Wazuh Helm Chart
 
-![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square)
+![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square)
 ![AppVersion: 4.12.0](https://img.shields.io/badge/AppVersion-4.12.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/wazuh-helm)](https://artifacthub.io/packages/helm/wazuh-helm/wazuh)
 

--- a/charts/wazuh/templates/manager/configmap.yaml
+++ b/charts/wazuh/templates/manager/configmap.yaml
@@ -17,11 +17,4 @@ data:
     {{- tpl .Values.wazuh.worker.conf . | indent 2 }}
   worker_local_internal_options.conf: |
     {{- tpl .Values.wazuh.worker.localInternalOptions . | indent 2 }}
-  ar.conf: |
-    <active-response>
-      <command>firewall-drop</command>
-      <location>local</location>
-      <level>6</level>
-      <timeout>600</timeout>
-    </active-response>
 

--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -136,10 +136,6 @@ spec:
             - name: {{ include "wazuh.fullname" . }}-manager-master
               mountPath: /var/lib/filebeat
               subPath: filebeat/var/lib/filebeat
-            - name: config
-              mountPath: /var/ossec/etc/shared/ar.conf
-              subPath: ar.conf
-              readOnly: true
           ports:
             - containerPort: {{ .Values.wazuh.master.service.ports.registration }}
               name: registration

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -138,10 +138,6 @@ spec:
             - name: {{ include "wazuh.fullname" . }}-manager-worker
               mountPath: /var/lib/filebeat
               subPath: filebeat/var/lib/filebeat
-            - name: config
-              mountPath: /var/ossec/etc/shared/ar.conf
-              subPath: ar.conf
-              readOnly: true
           ports:
             - containerPort: {{ .Values.wazuh.worker.service.ports.agentEvents }}
               name: agents-events


### PR DESCRIPTION
## Summary
- remove deprecated `ar.conf` from manager configmap and statefulsets
- bump chart version to 0.0.11
- update docs to reflect new version

## Testing
- `helm lint charts/wazuh`

------
https://chatgpt.com/codex/tasks/task_e_687a92b8743c832ab57538e22f0a3c92